### PR TITLE
Added Fly and Vanish Commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,11 @@ Autocomplete:
 - **/fly**: Toggle flight mode on or off.
 - **/fly Player**: Toggle flight mode on or off for a target player.
 
+#### Vanish
+
+- **/vanish**: Toggle vanish mode on or off.
+- **/vanish Player**: Toggle vanish mode on or off for a target player.
+
 #### Warps
 
 - **/warp set Name**: Set a warp point at your current location.
@@ -199,6 +204,13 @@ Autocomplete:
 - **/home list**: List all home locations.
 
 ## Permissions
+
+#### Vanish
+
+- **niso.vanish.use**: Allows players to use the vanish command.
+- **niso.vanish.others**: Allows the player to toggle vanish on a target player.
+- **niso.vanish.bypass**: Allows the target player to bypass the vanish toggle.
+- **niso.vanish.see**: Allows the player to see vanished players.
 
 #### Fly
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ formatting.
 
 - **Warps**: Set and manage warp points for easy teleportation.
 - **Homes**: Allow players to set and teleport to their homes.
+- **Fly**: Toggle flight mode for yourself or other players.
 - **Autocomplete**: Autocomplete commands for warps, homes and more.
 - **Customizable Server MOTD**: Set a custom Message of the Day (MOTD) using MiniMessage formatting.
 - **Customizable Join/Leave Messages**: Customize join and leave messages with MiniMessage and PlaceholderAPI support.
@@ -178,21 +179,32 @@ Autocomplete:
 
 ## Commands
 
+#### Fly
+
+- **/fly**: Toggle flight mode on or off.
+- **/fly Player**: Toggle flight mode on or off for a target player.
+
 #### Warps
 
-- **/warp set (Name)**: Set a warp point at your current location.
-- **/warp delete (Name)**: Remove a warp point.
-- **/warp tp (Name)**: Teleport to a warp point.
+- **/warp set Name**: Set a warp point at your current location.
+- **/warp delete Name**: Remove a warp point.
+- **/warp tp Name**: Teleport to a warp point.
 - **/warp list**: List all warp points.
 
 #### Homes
 
-- **/home set (Name)**: Set your home location.
-- **/home delete (Name)**: Remove your home location.
-- **/home tp (Name)**: Teleport to your home location.
+- **/home set Name**: Set your home location.
+- **/home delete Name**: Remove your home location.
+- **/home tp Name**: Teleport to your home location.
 - **/home list**: List all home locations.
 
 ## Permissions
+
+#### Fly
+
+- **niso.fly.use**: Allows players to use the fly command.
+- **niso.fly.others**: Allows the player to toggle flight on a target player.
+- **niso.fly.bypass**: Allows the target player to bypass the flight toggle.
 
 #### Warps
 

--- a/src/main/java/moe/niso/NisoPlugin.java
+++ b/src/main/java/moe/niso/NisoPlugin.java
@@ -1,5 +1,6 @@
 package moe.niso;
 
+import moe.niso.commands.FlyCommand;
 import moe.niso.commands.HomeCommand;
 import moe.niso.commands.WarpCommand;
 import moe.niso.listeners.*;
@@ -97,6 +98,7 @@ public final class NisoPlugin extends JavaPlugin {
     private void registerCommands() {
         getCmd("home").setExecutor(new HomeCommand());
         getCmd("warp").setExecutor(new WarpCommand());
+        getCmd("fly").setExecutor(new FlyCommand());
 
         getLogger().info(logPrefixManager + "Commands registered!");
     }

--- a/src/main/java/moe/niso/NisoPlugin.java
+++ b/src/main/java/moe/niso/NisoPlugin.java
@@ -2,6 +2,7 @@ package moe.niso;
 
 import moe.niso.commands.FlyCommand;
 import moe.niso.commands.HomeCommand;
+import moe.niso.commands.VanishCommand;
 import moe.niso.commands.WarpCommand;
 import moe.niso.listeners.*;
 import moe.niso.managers.ConfigManager;
@@ -99,6 +100,7 @@ public final class NisoPlugin extends JavaPlugin {
         getCmd("home").setExecutor(new HomeCommand());
         getCmd("warp").setExecutor(new WarpCommand());
         getCmd("fly").setExecutor(new FlyCommand());
+        getCmd("vanish").setExecutor(new VanishCommand());
 
         getLogger().info(logPrefixManager + "Commands registered!");
     }

--- a/src/main/java/moe/niso/commands/FlyCommand.java
+++ b/src/main/java/moe/niso/commands/FlyCommand.java
@@ -1,0 +1,96 @@
+package moe.niso.commands;
+
+import moe.niso.NisoPlugin;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.TabExecutor;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
+
+public class FlyCommand implements TabExecutor {
+    private final NisoPlugin plugin = NisoPlugin.getInstance();
+
+    @Override
+    public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String @NotNull [] args) {
+        if (!(sender instanceof Player player)) {
+            sender.sendMessage(plugin.prefixMessage(Component.text("Only players can use this command!").color(NamedTextColor.RED)));
+            return true;
+        }
+
+        if (!player.hasPermission("niso.fly.use")) {
+            player.sendMessage(plugin.prefixMessage(Component.text("You do not have permission to use this command!").color(NamedTextColor.RED)));
+            return true;
+        }
+
+        if (args.length == 1) {
+            if (!player.hasPermission("niso.fly.others")) {
+                player.sendMessage(plugin.prefixMessage(Component.text("You do not have permission to use this command!").color(NamedTextColor.RED)));
+                return true;
+            }
+
+            Player targetPlayer = plugin.getServer().getPlayer(args[0]);
+
+            if (targetPlayer == null) {
+                player.sendMessage(plugin.prefixMessage(Component.text("Player not found!").color(NamedTextColor.RED)));
+                return true;
+            }
+
+            if (targetPlayer.hasPermission("niso.fly.bypass")) {
+                player.sendMessage(plugin.prefixMessage(Component.text("You cannot toggle fly for this player!").color(NamedTextColor.RED)));
+                return true;
+            }
+
+            toggleFly(player, targetPlayer);
+            return true;
+        }
+
+        toggleFly(player, null);
+        return true;
+    }
+
+    private void toggleFly(Player player, Player targetPlayer) {
+        if (targetPlayer != null) {
+            if (targetPlayer.getAllowFlight()) {
+                targetPlayer.setAllowFlight(false);
+                targetPlayer.setFlying(false);
+
+                player.sendMessage(plugin.prefixMessage(Component.text("Fly mode disabled for " + targetPlayer.getName()).color(NamedTextColor.RED)));
+                targetPlayer.sendMessage(plugin.prefixMessage(Component.text("Fly mode disabled!").color(NamedTextColor.RED)));
+            } else {
+                targetPlayer.setAllowFlight(true);
+                targetPlayer.setFlying(true);
+
+                player.sendMessage(plugin.prefixMessage(Component.text("Fly mode enabled for " + targetPlayer.getName()).color(NamedTextColor.GREEN)));
+                targetPlayer.sendMessage(plugin.prefixMessage(Component.text("Fly mode enabled!").color(NamedTextColor.GREEN)));
+            }
+        } else {
+            if (player.getAllowFlight()) {
+                player.setAllowFlight(false);
+                player.setFlying(false);
+
+                player.sendMessage(plugin.prefixMessage(Component.text("Fly mode disabled!").color(NamedTextColor.RED)));
+            } else {
+                player.setAllowFlight(true);
+                player.setFlying(true);
+
+                player.sendMessage(plugin.prefixMessage(Component.text("Fly mode enabled!").color(NamedTextColor.GREEN)));
+            }
+        }
+    }
+
+    @Override
+    public @Nullable List<String> onTabComplete(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String @NotNull [] args) {
+        if (args.length == 1) {
+            return plugin.getServer().getOnlinePlayers().stream()
+                    .map(Player::getName)
+                    .filter(name -> name.toLowerCase().startsWith(args[0].toLowerCase()))
+                    .toList();
+        }
+        return List.of();
+    }
+}

--- a/src/main/java/moe/niso/commands/VanishCommand.java
+++ b/src/main/java/moe/niso/commands/VanishCommand.java
@@ -1,0 +1,112 @@
+package moe.niso.commands;
+
+import moe.niso.NisoPlugin;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import org.bukkit.Bukkit;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.TabExecutor;
+import org.bukkit.entity.Player;
+import org.bukkit.metadata.FixedMetadataValue;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
+
+public class VanishCommand implements TabExecutor {
+    private final NisoPlugin plugin = NisoPlugin.getInstance();
+
+    @Override
+    public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String @NotNull [] args) {
+        if (!(sender instanceof Player player)) {
+            sender.sendMessage(plugin.prefixMessage(Component.text("Only players can use this command!").color(NamedTextColor.RED)));
+            return true;
+        }
+
+        if (!player.hasPermission("niso.vanish.use")) {
+            player.sendMessage(plugin.prefixMessage(Component.text("You do not have permission to use this command!").color(NamedTextColor.RED)));
+            return true;
+        }
+
+        if (args.length == 1) {
+            if (!player.hasPermission("niso.vanish.others")) {
+                player.sendMessage(plugin.prefixMessage(Component.text("You do not have permission to use this command!").color(NamedTextColor.RED)));
+                return true;
+            }
+
+            Player targetPlayer = plugin.getServer().getPlayer(args[0]);
+
+            if (targetPlayer == null) {
+                player.sendMessage(plugin.prefixMessage(Component.text("Player not found!").color(NamedTextColor.RED)));
+                return true;
+            }
+
+            if (targetPlayer.hasPermission("niso.vanish.bypass")) {
+                player.sendMessage(plugin.prefixMessage(Component.text("You cannot toggle vanish for this player!").color(NamedTextColor.RED)));
+                return true;
+            }
+
+            toggleVanish(player, targetPlayer);
+            return true;
+        }
+
+        toggleVanish(player, null);
+        return true;
+    }
+
+    private void toggleVanish(Player player, Player targetPlayer) {
+        if (targetPlayer != null) {
+            if (targetPlayer.hasMetadata("vanished")) {
+                targetPlayer.removeMetadata("vanished", plugin);
+
+                for (Player onlinePlayer : Bukkit.getOnlinePlayers()) {
+                    onlinePlayer.showPlayer(plugin, targetPlayer);
+                }
+
+                player.sendMessage(plugin.prefixMessage(Component.text("Vanish mode disabled for " + targetPlayer.getName()).color(NamedTextColor.GREEN)));
+                targetPlayer.sendMessage(plugin.prefixMessage(Component.text("You are now visible!").color(NamedTextColor.GREEN)));
+            } else {
+                targetPlayer.setMetadata("vanished", new FixedMetadataValue(plugin, true));
+
+                for (Player onlinePlayer : Bukkit.getOnlinePlayers()) {
+                    if (!onlinePlayer.hasPermission("niso.vanish.see")) {
+                        onlinePlayer.hidePlayer(plugin, targetPlayer);
+                    }
+                }
+
+                player.sendMessage(plugin.prefixMessage(Component.text("Vanish mode enabled for " + targetPlayer.getName()).color(NamedTextColor.RED)));
+                targetPlayer.sendMessage(plugin.prefixMessage(Component.text("You are now invisible!").color(NamedTextColor.GREEN)));
+            }
+        } else {
+            if (player.hasMetadata("vanished")) {
+                player.removeMetadata("vanished", plugin);
+
+                for (Player onlinePlayer : Bukkit.getOnlinePlayers()) {
+                    onlinePlayer.showPlayer(plugin, player);
+                }
+
+                player.sendMessage(plugin.prefixMessage(Component.text("You are now visible!").color(NamedTextColor.GREEN)));
+            } else {
+                player.setMetadata("vanished", new FixedMetadataValue(plugin, true));
+
+                for (Player onlinePlayer : Bukkit.getOnlinePlayers()) {
+                    onlinePlayer.hidePlayer(plugin, player);
+                }
+
+                player.sendMessage(plugin.prefixMessage(Component.text("You are now invisible!").color(NamedTextColor.GREEN)));
+            }
+        }
+    }
+
+    @Override
+    public @Nullable List<String> onTabComplete(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String @NotNull [] args) {
+        if (args.length == 1) {
+            return plugin.getServer().getOnlinePlayers().stream()
+                    .map(Player::getName)
+                    .filter(name -> name.toLowerCase().startsWith(args[0].toLowerCase()))
+                    .toList();
+        }
+        return List.of();
+    }
+}

--- a/src/main/java/moe/niso/listeners/JoinListener.java
+++ b/src/main/java/moe/niso/listeners/JoinListener.java
@@ -20,6 +20,28 @@ public class JoinListener implements Listener {
     public void onJoin(PlayerJoinEvent event) {
         final Player player = event.getPlayer();
 
+        // If the joining player is vanished, hide them from other players
+        if (player.hasMetadata("vanished")) {
+            for (Player onlinePlayer : plugin.getServer().getOnlinePlayers()) {
+                if (!onlinePlayer.hasPermission("niso.vanish.see")) {
+                    player.hidePlayer(plugin, onlinePlayer);
+                } else {
+                    player.showPlayer(plugin, onlinePlayer);
+                }
+            }
+        }
+
+        // If an online player is vanished, hide them from the joining player
+        for (Player onlinePlayer : plugin.getServer().getOnlinePlayers()) {
+            if (onlinePlayer.hasMetadata("vanished")) {
+                if (player.hasPermission("niso.vanish.see")) {
+                    player.showPlayer(plugin, onlinePlayer);
+                } else {
+                    player.hidePlayer(plugin, onlinePlayer);
+                }
+            }
+        }
+
         // Sending welcome messages
 
         final ConfigurationSection welcomeConfig = plugin.getConfig().getConfigurationSection("welcome-message");
@@ -59,7 +81,6 @@ public class JoinListener implements Listener {
                 player.sendMessage(updateMessageComponent);
             }
         }
-
 
         // Updating the tablist
         final ConfigurationSection tablistConfig = plugin.getConfig().getConfigurationSection("tablist");

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -18,3 +18,7 @@ commands:
     usage: /home <set/delete/list/teleport> [name]
     aliases: [ h ]
     permission: niso.home.use
+  fly:
+    description: Toggles the flight mode
+    usage: /fly [player]
+    permission: niso.fly.use

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -22,3 +22,7 @@ commands:
     description: Toggles the flight mode
     usage: /fly [player]
     permission: niso.fly.use
+  vanish:
+    description: Toggles the vanish mode
+    usage: /vanish [player]
+    permission: niso.vanish.use


### PR DESCRIPTION
## 1. Vanish Self
**Command:** `/vanish`

### Steps:
- Join the server as a player with `niso.vanish.use` permission.
- Run `/vanish`.
- Observe that:
  - The player becomes invisible to others.
  - They receive the message: `"You are now invisible!"`
  - Other players (without `niso.vanish.see`) no longer see them.
  - Players with `niso.vanish.see` still see them.
  - `vanished` metadata is set on the player.

- Run `/vanish` again.
  - The player becomes visible to all.
  - They receive the message: `"You are now visible!"`
  - `vanished` metadata is removed.

---

## 2. Vanish Others
**Command:** `/vanish <player>`

### Steps:
- Use a player with both:
  - `niso.vanish.use`
  - `niso.vanish.others`

- Run `/vanish <target>`.
  - If the target exists and has no `niso.vanish.bypass`:
    - They should be hidden from players without `niso.vanish.see`.
    - The target gets: `"You are now invisible!"`
    - The sender gets: `"Vanish mode enabled for <target>"`
  - Run it again to toggle off:
    - Target becomes visible again.
    - Both receive confirmation messages.

---

## 3. Permission Denial Tests

### Self Vanish Denial:
- Join as a player **without** `niso.vanish.use`.
- Run `/vanish` — expect:
  - `"You do not have permission to use this command!"`

### Vanish Others Denial:
- Join with `niso.vanish.use` **but not** `niso.vanish.others`.
- Run `/vanish <other>` — expect same permission denial message.

### Vanish Bypass Check:
- Target a player with `niso.vanish.bypass`.
- Expect:
  - `"You cannot toggle vanish for this player!"`

---

## 4. Join Behavior When Vanished

### Steps:
- Vanish a player (`/vanish`).
- Log out.
- Rejoin.
- Expect:
  - Vanished player **remains hidden** from those without `niso.vanish.see`.
  - Vanished player **is visible** to those **with** `niso.vanish.see`.

---

## 5. Join Behavior With Other Vanished Players

### Steps:
- Have **at least one player already vanished** on the server.
- Join with:
  - A player **with** `niso.vanish.see` — they should see the vanished player.
  - A player **without** that permission — they should **not** see them.

---

## 6. Tab Completion Test

### Steps:
- Start typing `/vanish <name>` — tab should autocomplete **online players**.
- Confirm case-insensitive matching works.

---

## Optional (Edge Case) Tests

- Test toggling vanish **rapidly**.
- Confirm that vanished players:
  - Still take damage (or not, depending on other logic).
  - Still appear on the tab list (or not, based on tablist config).
